### PR TITLE
Git ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
A .gitignore file allows us to ignore files that exist locally in our project directory, but should not be tracked by Git as part of the repository. 

.DS_Store is a metadata file generated by MacOS that stores metadata about the containing directory, it's specific to macs and has no meaning for the project.

Ignoring .DS_Store and other OS generated files is common practice.